### PR TITLE
ci(e2e): made e2e test action only run on master and PR

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,8 +1,15 @@
 name: End-to-end tests
-on: [push]
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
 jobs:
   cypress-run:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -12,4 +19,4 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           start: npm start
-          wait-on: 'http://localhost:8888'
+          wait-on: "http://localhost:8888"


### PR DESCRIPTION
End-to-end testing will only run when pushing to the master branch or submitting a PR on the maser
![image](https://user-images.githubusercontent.com/17064586/109455857-7e6fc480-7a92-11eb-9465-6aa10d1af792.png)

