### PR TITLE
Feat format ratio 0412-1033

### DIFF
--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -2,12 +2,18 @@
 
 import { DOWNLOAD_DIR, TEST_TORRENT } from "../../fixtures/constants"
 
-export const addTestTorrent = () => {
+export const addTestTorrent = (autoStart = true) => {
   cy.getByTestId("add-btn").click();
   cy.getByTestId("download-dir").clear();
   cy.getByTestId("download-dir").type(DOWNLOAD_DIR);
   cy.getByTestId("torrent-link").type(TEST_TORRENT.URL);
   cy.get("[data-testid=advanced-mode]").uncheck();
+  if (autoStart) {
+    cy.get("[data-testid=auto-start]").check();
+  } else {
+    cy.get("[data-testid=auto-start]").uncheck();
+  }
+  cy.get("[data-testid=auto-start]").uncheck();
   cy.contains("OK").click();
   cy.contains("Successfully added!");
   cy.contains(TEST_TORRENT.NAME);

--- a/cypress/integration/list.spec.js
+++ b/cypress/integration/list.spec.js
@@ -15,6 +15,6 @@ context('test torrent list', () => {
   })
 
   it('should format ratio if ratio < 0', () => {
-    cy.contains(TEST_TORRENT.NAME).closest('.MuiDataGrid-row').find('[data-field=ratio]').contains('0')
+    cy.contains(TEST_TORRENT.NAME).closest('.MuiDataGrid-row').find('[data-field=uploadRatio]').contains('0')
   })
 })

--- a/cypress/integration/list.spec.js
+++ b/cypress/integration/list.spec.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+import { removeTestTorrent, addTestTorrent } from "./common"
+import { TEST_TORRENT } from "../fixtures/constants"
+
+context('test torrent list', () => {
+  beforeEach(() => {
+    cy.visit(`http://zj9495:zj9495@localhost:8888/transmission-client`)
+    cy.verifyConnected()
+    addTestTorrent(false)
+  })
+
+  afterEach(() => {
+    removeTestTorrent()
+  })
+
+  it('should format ratio if ratio < 0', () => {
+    cy.contains(TEST_TORRENT.NAME).closest('.MuiDataGrid-row').find('[data-field=ratio]').contains('0')
+  })
+})

--- a/src/components/TorrentTable/index.tsx
+++ b/src/components/TorrentTable/index.tsx
@@ -100,6 +100,7 @@ const columns: GridColDef[] = [
     headerName: ((
       <FormattedMessage id="torrent.fields.uploadRatio" />
     ) as unknown) as string,
+    valueFormatter: ({ value }) => (Number(value) < 0 ? 0 : value),
   },
   {
     field: "status",


### PR DESCRIPTION
格式化`Ratio`，当值小于0时，显示为0
![image](https://user-images.githubusercontent.com/17064586/114984066-edc73980-9ec3-11eb-8ac5-f398aabe9b37.png)
由于muix的bug，valueFormatter未生效，等待修复 https://github.com/mui-org/material-ui-x/issues/1424
由于muix的虚拟滚动尚不支持jest，单元测试未通过，等待修复https://github.com/mui-org/material-ui-x/issues/1151