### PR TITLE
fix(table): fix tooltip for torrent names

### DIFF
--- a/src/components/TorrentTable/renderName.tsx
+++ b/src/components/TorrentTable/renderName.tsx
@@ -70,9 +70,13 @@ const NameLink = React.memo((props: NameLinkProps) => {
     () => (
       <>
         <span>{name}</span>
-        <br />
-        <br />
-        {errorString && <span>{errorString}</span>}
+        {errorString && (
+          <>
+            <br />
+            <br />
+            <span>{errorString}</span>
+          </>
+        )}
       </>
     ),
     [name, errorString]


### PR DESCRIPTION
before:
<img width="504" alt="image" src="https://user-images.githubusercontent.com/17064586/167241714-8a624265-a3cb-4882-96d5-455944a12f59.png">

after:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/17064586/167241708-863ad291-7170-4920-b65f-b2a1073796ec.png">
