### PR TITLE
fix(torrent): display the correct number of  seeders & leechers

### DIFF
--- a/cypress/fixtures/torrent/detail.json
+++ b/cypress/fixtures/torrent/detail.json
@@ -157,7 +157,7 @@
         "id": 51,
         "isPrivate": true,
         "labels": [],
-        "leecherCount": 5,
+        "leecherCount": 0,
         "magnetLink": "magnet:?xt=urn:btih:d3d0774b8d3d1389a956899250de94d5f11b29be&dn=Beethoven%20-%20Piano%20Trio%20in%20C%20minor,%20Triple%20Concerto%20%5BOborin,%20Oistrakh,%20Knushevitskiy%5D%20%282011%29%20%5BFLAC%5D&tr=http%3A%2F%2Fwww.hdarea.co%2Fannounce.php%3Fpasskey%3Dddeb644cd5dac0c3c3b00152e415fdf8",
         "metadataPercentComplete": 1,
         "name": "Beethoven - Piano Trio in C minor, Triple Concerto [Oborin, Oistrakh, Knushevitskiy] (2011) [FLAC]",
@@ -190,7 +190,7 @@
         "seedIdleMode": 0,
         "seedRatioLimit": 2,
         "seedRatioMode": 0,
-        "seederCount": 4,
+        "seederCount": 0,
         "status": 4,
         "totalSize": 257751467,
         "trackerStats": [
@@ -214,12 +214,12 @@
             "lastScrapeSucceeded": true,
             "lastScrapeTime": 1627629701,
             "lastScrapeTimedOut": false,
-            "leecherCount": 1,
+            "leecherCount": 5,
             "nextAnnounceTime": 1627633296,
             "nextScrapeTime": 1627631510,
             "scrape": "http://www.hdarea.co/scrape.php?passkey=ddeb644cd5dac0c3c3b00152e415fdf8",
             "scrapeState": 1,
-            "seederCount": 2,
+            "seederCount": 4,
             "tier": 0
           }
         ],

--- a/cypress/integration/torrentDetail.spec.ts
+++ b/cypress/integration/torrentDetail.spec.ts
@@ -150,10 +150,10 @@ context("test torrent detail", () => {
     cy.getByTestId("torrent-tracker-downloadCount").contains("35");
 
     cy.getByTestId("torrent-tracker-leecherCount").contains("Leecher count");
-    cy.getByTestId("torrent-tracker-leecherCount").contains("1");
+    cy.getByTestId("torrent-tracker-leecherCount").contains("5");
 
     cy.getByTestId("torrent-tracker-seederCount").contains("Seeder count");
-    cy.getByTestId("torrent-tracker-seederCount").contains("2");
+    cy.getByTestId("torrent-tracker-seederCount").contains("4");
 
     cy.getByTestId("torrent-tracker-lastAnnounceSucceeded").contains(
       "Succeeded"

--- a/src/components/TorrentDetailDrawer/BaseInfo.tsx
+++ b/src/components/TorrentDetailDrawer/BaseInfo.tsx
@@ -79,7 +79,7 @@ const BasicInfo = (props: BasicInfoProp) => {
               id="torrents.details.general.connected"
               values={{
                 connected: torrent?.peersGettingFromUs,
-                total: torrent?.leecherCount,
+                total: torrent?.trackerStats[0]?.leecherCount || 0,
               }}
             />
           ),
@@ -93,7 +93,7 @@ const BasicInfo = (props: BasicInfoProp) => {
               id="torrents.details.general.connected"
               values={{
                 connected: torrent?.peersSendingToUs,
-                total: torrent?.seederCount,
+                total: torrent?.trackerStats[0]?.seederCount || 0,
               }}
             />
           ),

--- a/src/components/TorrentTable/index.tsx
+++ b/src/components/TorrentTable/index.tsx
@@ -137,11 +137,19 @@ const TorrentTable: React.FC = () => {
         field: "seederCount",
         headerName: intl.formatMessage({ id: "torrent.fields.seederCount" }),
         width: COLUMNS_WIDTH[locale].seederCount,
+        renderCell: (params) =>
+          `${params.row.trackerStats[0]?.seederCount || 0} (${
+            params.value || 0
+          })`,
       },
       {
         field: "leecherCount",
         headerName: intl.formatMessage({ id: "torrent.fields.leecherCount" }),
         width: COLUMNS_WIDTH[locale].leecherCount,
+        renderCell: (params) =>
+          `${params.row.trackerStats[0]?.leecherCount || 0} (${
+            params.value || 0
+          })`,
       },
       {
         field: "rateDownload",


### PR DESCRIPTION
before:
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/17064586/167385953-d094f1d1-448c-432a-8948-fe53658d1941.png">
<img width="900" alt="image" src="https://user-images.githubusercontent.com/17064586/167386022-b90db5bd-9e9f-47b3-ae24-022a7c570025.png">


after:
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/17064586/167385820-8eaf2532-4f95-430a-9df9-b197bda71ee1.png">
<img width="765" alt="image" src="https://user-images.githubusercontent.com/17064586/167385875-21c40adf-3757-4a1b-b745-4fa07b4cef36.png">
